### PR TITLE
Fix ImageSharp pixel span usage on Windows forms

### DIFF
--- a/src/MuLauncher.Launcher.WinForms/Forms/LauncherSplashForm.cs
+++ b/src/MuLauncher.Launcher.WinForms/Forms/LauncherSplashForm.cs
@@ -6,7 +6,6 @@ using System.Windows.Forms;
 using MuLauncher.Shared.UI.Models;
 using MuLauncher.Shared.UI.Rendering;
 using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Png;
 
 namespace MuLauncher.Launcher.WinForms.Forms;
@@ -131,7 +130,7 @@ public sealed class LauncherSplashForm : Form
         Invalidate();
     }
 
-    private static Bitmap ConvertToBitmap(Image<Rgba32> image)
+    private static Bitmap ConvertToBitmap(SixLabors.ImageSharp.Image<Rgba32> image)
     {
         using var memory = new System.IO.MemoryStream();
         image.Save(memory, new PngEncoder());
@@ -139,13 +138,13 @@ public sealed class LauncherSplashForm : Form
         return new Bitmap(memory);
     }
 
-    private static Region? CreateRegionFromImage(Image<Rgba32> image)
+    private static Region? CreateRegionFromImage(SixLabors.ImageSharp.Image<Rgba32> image)
     {
         var path = new GraphicsPath();
 
         for (var y = 0; y < image.Height; y++)
         {
-            var span = image.GetPixelRowSpan(y);
+            var span = image.Frames.RootFrame.GetPixelRowSpan(y);
             var start = -1;
             for (var x = 0; x < span.Length; x++)
             {

--- a/src/MuLauncher.Launcher.WinForms/Forms/LauncherSplashPreviewForm.cs
+++ b/src/MuLauncher.Launcher.WinForms/Forms/LauncherSplashPreviewForm.cs
@@ -6,7 +6,6 @@ using System.Windows.Forms;
 using MuLauncher.Shared.UI.Controls;
 using MuLauncher.Shared.UI.Models;
 using MuLauncher.Shared.UI.Rendering;
-using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.PixelFormats;
 
@@ -123,7 +122,7 @@ public sealed class LauncherSplashPreviewForm : Form
         }
     }
 
-    private static Bitmap ToBitmap(Image<Rgba32> image)
+    private static Bitmap ToBitmap(SixLabors.ImageSharp.Image<Rgba32> image)
     {
         using var stream = new MemoryStream();
         image.Save(stream, new PngEncoder());

--- a/src/MuLauncher.Shared.UI/Rendering/LauncherSplashRenderer.cs
+++ b/src/MuLauncher.Shared.UI/Rendering/LauncherSplashRenderer.cs
@@ -30,10 +30,13 @@ public static class LauncherSplashRenderer
                     region.Mutate(ctx => ctx.Resize(output.Width, output.Height));
                 }
 
+                var outputFrame = output.Frames.RootFrame;
+                var regionFrame = region.Frames.RootFrame;
+
                 for (var y = 0; y < output.Height; y++)
                 {
-                    var row = output.GetPixelRowSpan(y);
-                    var maskRow = region.GetPixelRowSpan(y);
+                    var row = outputFrame.GetPixelRowSpan(y);
+                    var maskRow = regionFrame.GetPixelRowSpan(y);
                     for (var x = 0; x < row.Length; x++)
                     {
                         row[x].A = maskRow[x].PackedValue;

--- a/tests/MuLauncher.Visual.Tests/VisualSnapshotComparer.cs
+++ b/tests/MuLauncher.Visual.Tests/VisualSnapshotComparer.cs
@@ -105,11 +105,15 @@ internal static class VisualSnapshotComparer
         long diffPixels = 0;
         using var diffImage = new Image<Rgba32>(expected.Width, expected.Height);
 
+        var expectedFrame = expected.Frames.RootFrame;
+        var actualFrame = actual.Frames.RootFrame;
+        var diffFrame = diffImage.Frames.RootFrame;
+
         for (var y = 0; y < expected.Height; y++)
         {
-            var expectedRow = expected.GetPixelRowSpan(y);
-            var actualRow = actual.GetPixelRowSpan(y);
-            var diffRow = diffImage.GetPixelRowSpan(y);
+            var expectedRow = expectedFrame.GetPixelRowSpan(y);
+            var actualRow = actualFrame.GetPixelRowSpan(y);
+            var diffRow = diffFrame.GetPixelRowSpan(y);
 
             for (var x = 0; x < expectedRow.Length; x++)
             {


### PR DESCRIPTION
## Summary
- qualify ImageSharp image types in Windows Forms splash screens to avoid ambiguity with System.Drawing
- access pixel rows via the root frame to maintain compatibility with ImageSharp's API
- update visual comparer to use frame pixel spans consistently

## Testing
- Not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d4797250f08332a23b7716ea991588