### PR TITLE
Clarify ImageSharp usage for splash rendering

### DIFF
--- a/src/MuLauncher.Launcher.WinForms/Forms/LauncherSplashForm.cs
+++ b/src/MuLauncher.Launcher.WinForms/Forms/LauncherSplashForm.cs
@@ -5,9 +5,9 @@ using System.Drawing.Drawing2D;
 using System.Windows.Forms;
 using MuLauncher.Shared.UI.Models;
 using MuLauncher.Shared.UI.Rendering;
-using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.PixelFormats;
 
 namespace MuLauncher.Launcher.WinForms.Forms;
 
@@ -131,7 +131,7 @@ public sealed class LauncherSplashForm : Form
         Invalidate();
     }
 
-    private static Bitmap ConvertToBitmap(Image<Rgba32> image)
+    private static Bitmap ConvertToBitmap(SixLabors.ImageSharp.Image<Rgba32> image)
     {
         using var memory = new System.IO.MemoryStream();
         image.Save(memory, new PngEncoder());
@@ -139,13 +139,13 @@ public sealed class LauncherSplashForm : Form
         return new Bitmap(memory);
     }
 
-    private static Region? CreateRegionFromImage(Image<Rgba32> image)
+    private static Region? CreateRegionFromImage(SixLabors.ImageSharp.Image<Rgba32> image)
     {
         var path = new GraphicsPath();
 
         for (var y = 0; y < image.Height; y++)
         {
-            var span = image.GetPixelRowSpan(y);
+            var span = image.Frames.RootFrame.GetPixelRowSpan(y);
             var start = -1;
             for (var x = 0; x < span.Length; x++)
             {

--- a/src/MuLauncher.Launcher.WinForms/Forms/LauncherSplashPreviewForm.cs
+++ b/src/MuLauncher.Launcher.WinForms/Forms/LauncherSplashPreviewForm.cs
@@ -6,7 +6,6 @@ using System.Windows.Forms;
 using MuLauncher.Shared.UI.Controls;
 using MuLauncher.Shared.UI.Models;
 using MuLauncher.Shared.UI.Rendering;
-using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.PixelFormats;
 
@@ -123,7 +122,7 @@ public sealed class LauncherSplashPreviewForm : Form
         }
     }
 
-    private static Bitmap ToBitmap(Image<Rgba32> image)
+    private static Bitmap ToBitmap(SixLabors.ImageSharp.Image<Rgba32> image)
     {
         using var stream = new MemoryStream();
         image.Save(stream, new PngEncoder());

--- a/src/MuLauncher.Shared.UI/Models/LauncherOptions.cs
+++ b/src/MuLauncher.Shared.UI/Models/LauncherOptions.cs
@@ -1,6 +1,6 @@
 using System;
 using System.IO;
-using SixLabors.ImageSharp;
+using ImageSharpImage = SixLabors.ImageSharp.Image;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace MuLauncher.Shared.UI.Models;
@@ -54,24 +54,24 @@ public sealed class LauncherOptions
 
     public bool HasSplashBackground => !string.IsNullOrWhiteSpace(SplashBackgroundData);
 
-    public Image<Rgba32> LoadSplashBackgroundImage()
+    public ImageSharpImage<Rgba32> LoadSplashBackgroundImage()
     {
         if (!HasSplashBackground)
         {
             throw new InvalidOperationException("Launcher options do not contain splash background data.");
         }
 
-        return Image.Load<Rgba32>(Convert.FromBase64String(SplashBackgroundData));
+        return ImageSharpImage.Load<Rgba32>(Convert.FromBase64String(SplashBackgroundData));
     }
 
-    public Image<L8>? LoadSplashRegionMask()
+    public ImageSharpImage<L8>? LoadSplashRegionMask()
     {
         if (string.IsNullOrWhiteSpace(SplashRegionData))
         {
             return null;
         }
 
-        return Image.Load<L8>(Convert.FromBase64String(SplashRegionData));
+        return ImageSharpImage.Load<L8>(Convert.FromBase64String(SplashRegionData));
     }
 
     public LauncherOptions Clone() => new()

--- a/src/MuLauncher.Shared.UI/Rendering/LauncherSplashRenderer.cs
+++ b/src/MuLauncher.Shared.UI/Rendering/LauncherSplashRenderer.cs
@@ -1,14 +1,15 @@
 using System;
 using MuLauncher.Shared.UI.Models;
-using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
+using ImageSharpImage = SixLabors.ImageSharp.Image;
 
 namespace MuLauncher.Shared.UI.Rendering;
 
 public static class LauncherSplashRenderer
 {
-    public static Image<Rgba32> Render(LauncherOptions options)
+    public static ImageSharpImage<Rgba32> Render(LauncherOptions options)
     {
         ArgumentNullException.ThrowIfNull(options);
 
@@ -30,10 +31,13 @@ public static class LauncherSplashRenderer
                     region.Mutate(ctx => ctx.Resize(output.Width, output.Height));
                 }
 
+                var outputFrame = output.Frames.RootFrame;
+                var regionFrame = region.Frames.RootFrame;
+
                 for (var y = 0; y < output.Height; y++)
                 {
-                    var row = output.GetPixelRowSpan(y);
-                    var maskRow = region.GetPixelRowSpan(y);
+                    var row = outputFrame.GetPixelRowSpan(y);
+                    var maskRow = regionFrame.GetPixelRowSpan(y);
                     for (var x = 0; x < row.Length; x++)
                     {
                         row[x].A = maskRow[x].PackedValue;

--- a/tests/MuLauncher.Visual.Tests/VisualSnapshotComparer.cs
+++ b/tests/MuLauncher.Visual.Tests/VisualSnapshotComparer.cs
@@ -1,14 +1,16 @@
 using System;
 using System.IO;
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
+using ImageSharpImage = SixLabors.ImageSharp.Image;
 
 namespace MuLauncher.Visual.Tests;
 
 internal static class VisualSnapshotComparer
 {
-    public static bool EnsureBaselineAndCompare(Image<Rgba32> current, string baselinePath, string receivedPath, string diffPath, out string message)
+    public static bool EnsureBaselineAndCompare(ImageSharpImage<Rgba32> current, string baselinePath, string receivedPath, string diffPath, out string message)
     {
         ArgumentNullException.ThrowIfNull(current);
         Directory.CreateDirectory(Path.GetDirectoryName(receivedPath)!);
@@ -26,19 +28,19 @@ internal static class VisualSnapshotComparer
         return Compare(baseline, current, receivedPath, diffPath, out message);
     }
 
-    private static Image<Rgba32> LoadBaselineImage(string baselinePath)
+    private static ImageSharpImage<Rgba32> LoadBaselineImage(string baselinePath)
     {
         if (TryGetBase64Info(baselinePath, out _))
         {
             var base64 = File.ReadAllText(baselinePath);
             var bytes = Convert.FromBase64String(base64);
-            return Image.Load<Rgba32>(bytes);
+            return ImageSharpImage.Load<Rgba32>(bytes);
         }
 
-        return Image.Load<Rgba32>(baselinePath);
+        return ImageSharpImage.Load<Rgba32>(baselinePath);
     }
 
-    private static void SaveBaselineImage(Image<Rgba32> image, string baselinePath)
+    private static void SaveBaselineImage(ImageSharpImage<Rgba32> image, string baselinePath)
     {
         if (TryGetBase64Info(baselinePath, out var rawExtension))
         {
@@ -72,7 +74,7 @@ internal static class VisualSnapshotComparer
         return true;
     }
 
-    private static void SaveImageToStream(Image<Rgba32> image, string extension, Stream destination)
+    private static void SaveImageToStream(ImageSharpImage<Rgba32> image, string extension, Stream destination)
     {
         var normalized = extension.TrimStart('.').ToLowerInvariant();
         switch (normalized)
@@ -93,7 +95,7 @@ internal static class VisualSnapshotComparer
         }
     }
 
-    private static bool Compare(Image<Rgba32> expected, Image<Rgba32> actual, string receivedPath, string diffPath, out string message)
+    private static bool Compare(ImageSharpImage<Rgba32> expected, ImageSharpImage<Rgba32> actual, string receivedPath, string diffPath, out string message)
     {
         if (expected.Width != actual.Width || expected.Height != actual.Height)
         {
@@ -103,13 +105,17 @@ internal static class VisualSnapshotComparer
         }
 
         long diffPixels = 0;
-        using var diffImage = new Image<Rgba32>(expected.Width, expected.Height);
+        using var diffImage = new ImageSharpImage<Rgba32>(expected.Width, expected.Height);
+
+        var expectedFrame = expected.Frames.RootFrame;
+        var actualFrame = actual.Frames.RootFrame;
+        var diffFrame = diffImage.Frames.RootFrame;
 
         for (var y = 0; y < expected.Height; y++)
         {
-            var expectedRow = expected.GetPixelRowSpan(y);
-            var actualRow = actual.GetPixelRowSpan(y);
-            var diffRow = diffImage.GetPixelRowSpan(y);
+            var expectedRow = expectedFrame.GetPixelRowSpan(y);
+            var actualRow = actualFrame.GetPixelRowSpan(y);
+            var diffRow = diffFrame.GetPixelRowSpan(y);
 
             for (var x = 0; x < expectedRow.Length; x++)
             {
@@ -148,16 +154,16 @@ internal static class VisualSnapshotComparer
         expected.B == actual.B &&
         expected.A == actual.A;
 
-    private static void SaveArtifacts(Image<Rgba32> actual, string receivedPath, string diffPath, int expectedWidth, int expectedHeight)
+    private static void SaveArtifacts(ImageSharpImage<Rgba32> actual, string receivedPath, string diffPath, int expectedWidth, int expectedHeight)
     {
         Directory.CreateDirectory(Path.GetDirectoryName(receivedPath)!);
-        using var canvas = new Image<Rgba32>(Math.Max(expectedWidth, actual.Width), Math.Max(expectedHeight, actual.Height));
+        using var canvas = new ImageSharpImage<Rgba32>(Math.Max(expectedWidth, actual.Width), Math.Max(expectedHeight, actual.Height));
         canvas.Mutate(ctx => ctx.Fill(Color.Black));
         canvas.SaveAsPng(diffPath);
         actual.SaveAsPng(receivedPath);
     }
 
-    private static void SaveArtifacts(Image<Rgba32> actual, string receivedPath, string diffPath, Image<Rgba32> diff)
+    private static void SaveArtifacts(ImageSharpImage<Rgba32> actual, string receivedPath, string diffPath, ImageSharpImage<Rgba32> diff)
     {
         Directory.CreateDirectory(Path.GetDirectoryName(receivedPath)!);
         diff.SaveAsPng(diffPath);


### PR DESCRIPTION
## Summary
- import SixLabors.ImageSharp.Advanced so GetPixelRowSpan extensions resolve
- alias SixLabors.ImageSharp.Image in shared splash APIs to avoid ambiguity with System.Drawing
- update visual snapshot comparer to use the ImageSharp alias consistently

## Testing
- Not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d4797250f08332a23b7716ea991588